### PR TITLE
Use node 11.9.0 in Appveyor builds

### DIFF
--- a/Source/SmallBasic.Client/SmallBasic.Client.csproj
+++ b/Source/SmallBasic.Client/SmallBasic.Client.csproj
@@ -38,7 +38,7 @@
     </ItemGroup>
 
     <Exec
-      Command="node --max-old-space-size=4000 $(MSBuildProjectDirectory)\node_modules\webpack\bin\webpack.js @(ClientWebPackArgs->'--%(Identity) %(Value)', ' ')"
+      Command="node --max-old-space-size=7168 $(MSBuildProjectDirectory)\node_modules\webpack\bin\webpack.js @(ClientWebPackArgs->'--%(Identity) %(Value)', ' ')"
       WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ environment:
   nodejs_version: "11.9.0"
   matrix:
     - configuration: Debug
-    - configuration: Release
 
 init:
   - cmd: git config --global core.autocrlf true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,16 @@ branches:
   - master
 
 environment:
+  nodejs_version: "11.9.0"
   matrix:
     - configuration: Debug
     - configuration: Release
 
 init:
   - cmd: git config --global core.autocrlf true
+
+install:
+  - ps: Install-Product node $env:nodejs_version
 
 build_script:
   - cmd: dotnet build /p:Configuration=%configuration% /p:TreatWarningsAsErrors=True


### PR DESCRIPTION
Older version are failing because of https://github.com/nodejs/node/issues/20738