### PR TITLE
Math.GetRandomNumber() should never return 0

### DIFF
--- a/Source/SmallBasic.Editor/Libraries/MathLibrary.cs
+++ b/Source/SmallBasic.Editor/Libraries/MathLibrary.cs
@@ -31,7 +31,7 @@ namespace SmallBasic.Editor.Libraries
 
         public decimal GetRadians(decimal angle) => (angle % 360) * (decimal)Math.PI / 180;
 
-        public decimal GetRandomNumber(decimal maxNumber) => Random.Next((int)Math.Max(1, maxNumber) + 1);
+        public decimal GetRandomNumber(decimal maxNumber) => Random.Next((int)Math.Max(1, maxNumber)) + 1;
 
         public decimal Log(decimal number) => (decimal)Math.Log10((double)number);
 


### PR DESCRIPTION
Fixes #17