### PR TITLE
Update graphics display on Program.Delay()

### DIFF
--- a/Source/SmallBasic.Editor/Libraries/ProgramLibrary.cs
+++ b/Source/SmallBasic.Editor/Libraries/ProgramLibrary.cs
@@ -8,10 +8,17 @@ namespace SmallBasic.Editor.Libraries
     using System.Threading;
     using System.Threading.Tasks;
     using SmallBasic.Compiler.Runtime;
+    using SmallBasic.Editor.Store;
 
     internal sealed class ProgramLibrary : IProgramLibrary
     {
-        public Task Delay(decimal milliSeconds) => Task.Delay((int)milliSeconds);
+        public Task Delay(decimal milliSeconds)
+        {
+            // Update display if needed
+            GraphicsDisplayStore.UpdateDisplay();
+
+            return Task.Delay((int)milliSeconds);
+        }
 
         public void End() => throw new InvalidOperationException("This should have been removed in binding.");
 


### PR DESCRIPTION
It is only updated with every instruction batch, which prevented animating properly on `Program.Delay()` calls.
Fixes #19