### PR TITLE
Set InvariantCulture for all tests

### DIFF
--- a/Source/SmallBasic.Tests/Compiler/BindingTests.cs
+++ b/Source/SmallBasic.Tests/Compiler/BindingTests.cs
@@ -10,7 +10,7 @@ namespace SmallBasic.Tests.Compiler
     using SmallBasic.Compiler.Diagnostics;
     using Xunit;
 
-    public sealed class BindingTests
+    public sealed class BindingTests : IClassFixture<CultureFixture>
     {
         [Fact]
         public void ItReportsInForLoopFromExpression()

--- a/Source/SmallBasic.Tests/Compiler/ParsingTests.cs
+++ b/Source/SmallBasic.Tests/Compiler/ParsingTests.cs
@@ -8,7 +8,7 @@ namespace SmallBasic.Tests.Compiler
     using SmallBasic.Compiler.Diagnostics;
     using Xunit;
 
-    public sealed class ParsingTests
+    public sealed class ParsingTests : IClassFixture<CultureFixture>
     {
         [Fact]
         public void ItReportsUnterminatedSubModules()

--- a/Source/SmallBasic.Tests/Compiler/ScanningTests.cs
+++ b/Source/SmallBasic.Tests/Compiler/ScanningTests.cs
@@ -8,7 +8,7 @@ namespace SmallBasic.Tests.Compiler
     using SmallBasic.Compiler.Diagnostics;
     using Xunit;
 
-    public sealed class ScanningTests
+    public sealed class ScanningTests : IClassFixture<CultureFixture>
     {
         [Fact]
         public void ItReportsUnterminatedStringLiterals()

--- a/Source/SmallBasic.Tests/CultureFixture.cs
+++ b/Source/SmallBasic.Tests/CultureFixture.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="CultureFixture.cs" company="2018 Omar Tawfik">
+// Copyright (c) 2018 Omar Tawfik. All rights reserved. Licensed under the MIT License. See LICENSE file in the project root for license information.
+// </copyright>
+
+namespace SmallBasic.Tests
+{
+    using System.Globalization;
+
+    public class CultureFixture
+    {
+        public CultureFixture()
+        {
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+        }
+    }
+}

--- a/Source/SmallBasic.Tests/Runtime/ExpressionTests.cs
+++ b/Source/SmallBasic.Tests/Runtime/ExpressionTests.cs
@@ -8,7 +8,7 @@ namespace SmallBasic.Tests.Runtime
     using SmallBasic.Compiler;
     using Xunit;
 
-    public sealed class ExpressionTests
+    public sealed class ExpressionTests : IClassFixture<CultureFixture>
     {
         [Fact]
         public Task NumericStringsAreTreatedAsNumbers()

--- a/Source/SmallBasic.Tests/Runtime/LibrariesTests.cs
+++ b/Source/SmallBasic.Tests/Runtime/LibrariesTests.cs
@@ -8,7 +8,7 @@ namespace SmallBasic.Tests.Runtime
     using SmallBasic.Compiler;
     using Xunit;
 
-    public sealed class LibrariesTests
+    public sealed class LibrariesTests : IClassFixture<CultureFixture>
     {
         [Theory]
         [InlineData(0, 0, "")]

--- a/Source/SmallBasic.Tests/Runtime/OperatorTests.cs
+++ b/Source/SmallBasic.Tests/Runtime/OperatorTests.cs
@@ -10,7 +10,7 @@ namespace SmallBasic.Tests.Runtime
     using SmallBasic.Compiler.Diagnostics;
     using Xunit;
 
-    public sealed class OperatorTests
+    public sealed class OperatorTests : IClassFixture<CultureFixture>
     {
         [Theory]
         // Adding numbers:

--- a/Source/SmallBasic.Tests/Runtime/RuntimeAnalysisTests.cs
+++ b/Source/SmallBasic.Tests/Runtime/RuntimeAnalysisTests.cs
@@ -9,7 +9,7 @@ namespace SmallBasic.Tests.Runtime
     using SmallBasic.Compiler.Binding;
     using Xunit;
 
-    public sealed class RuntimeAnalysisTests
+    public sealed class RuntimeAnalysisTests : IClassFixture<CultureFixture>
     {
         [Fact]
         public void ItDoesNotUseGraphicsWindowWhenNotNeeded()

--- a/Source/SmallBasic.Tests/Runtime/StatementsTests.cs
+++ b/Source/SmallBasic.Tests/Runtime/StatementsTests.cs
@@ -8,7 +8,7 @@ namespace SmallBasic.Tests.Runtime
     using SmallBasic.Compiler;
     using Xunit;
 
-    public sealed class StatementsTests
+    public sealed class StatementsTests : IClassFixture<CultureFixture>
     {
         [Fact]
         public Task ItEvaluatesSingleIfTrueExpression()

--- a/Source/SmallBasic.Tests/Services/CompletionItemProviderTests.cs
+++ b/Source/SmallBasic.Tests/Services/CompletionItemProviderTests.cs
@@ -13,7 +13,7 @@ namespace SmallBasic.Tests.Services
     using SmallBasic.Utilities;
     using Xunit;
 
-    public sealed class CompletionItemProviderTests
+    public sealed class CompletionItemProviderTests : IClassFixture<CultureFixture>
     {
         [Fact]
         public void CompletesLibrariesStartingWithT()

--- a/Source/SmallBasic.Tests/Services/HoverProviderTests.cs
+++ b/Source/SmallBasic.Tests/Services/HoverProviderTests.cs
@@ -13,7 +13,7 @@ namespace SmallBasic.Tests.Services
     using SmallBasic.Utilities.Resources;
     using Xunit;
 
-    public sealed class HoverProviderTests
+    public sealed class HoverProviderTests : IClassFixture<CultureFixture>
     {
         [Fact]
         public void NoHoverOnEmptyString()


### PR DESCRIPTION
Fixes #42. I only set CultureInfo in the test class with currently affected methods. Don't know if that is the best solution.