### PR TITLE
TextDisplay should switch to rendering with output.

### DIFF
--- a/Source/SmallBasic.Editor/Components/Display/TextDisplay.cs
+++ b/Source/SmallBasic.Editor/Components/Display/TextDisplay.cs
@@ -39,6 +39,8 @@ namespace SmallBasic.Editor.Components.Display
         internal async Task AppendOutput(OutputChunk chunk)
         {
             this.outputChunks.Add(chunk);
+            // Important to prevent th UI from freezing
+            await Task.Delay(1).ConfigureAwait(false);
             await JSInterop.Layout.ScrollIntoView(this.inputFieldRef).ConfigureAwait(false);
             this.StateHasChanged();
         }


### PR DESCRIPTION
An infinite loop printing characters would freeze the UI.
Discovered while fixing #47
Example:
```
ラベル:
サブ()
TextWindow.WriteLine(変数)
Goto ラベル

Sub サブ
  変数 = Math.GetRandomNumber(100)
EndSub
```