### PR TITLE
Fix Turtle SVG in Firefox.

### DIFF
--- a/Source/SmallBasic.Editor/Libraries/Graphics/TurtleGraphicsObject.cs
+++ b/Source/SmallBasic.Editor/Libraries/Graphics/TurtleGraphicsObject.cs
@@ -5,6 +5,7 @@
 namespace SmallBasic.Editor.Libraries.Graphics
 {
     using System.Collections.Generic;
+    using System.Globalization;
     using SmallBasic.Editor.Components;
     using SmallBasic.Editor.Libraries.Utilities;
 
@@ -13,7 +14,13 @@ namespace SmallBasic.Editor.Libraries.Graphics
         public TurtleGraphicsObject(GraphicsWindowStyles styles)
             : base(styles)
         {
+            this.Width = 48;
+            this.Height = 61;
         }
+
+        public decimal Width { get; set; }
+
+        public decimal Height { get; set; }
 
         public override void ComposeTree(TreeComposer composer)
         {
@@ -22,6 +29,9 @@ namespace SmallBasic.Editor.Libraries.Graphics
                 attributes: new Dictionary<string, string>
                 {
                     { "href", $"Turtle.svg" },
+                    /* width and height attributes required on Firefox */
+                    { "width", this.Width.ToString(CultureInfo.CurrentCulture) },
+                    { "height", this.Height.ToString(CultureInfo.CurrentCulture) }
                 });
         }
     }

--- a/Source/SmallBasic.Editor/Libraries/Graphics/TurtleGraphicsObject.cs
+++ b/Source/SmallBasic.Editor/Libraries/Graphics/TurtleGraphicsObject.cs
@@ -14,13 +14,11 @@ namespace SmallBasic.Editor.Libraries.Graphics
         public TurtleGraphicsObject(GraphicsWindowStyles styles)
             : base(styles)
         {
-            this.Width = 48;
-            this.Height = 61;
         }
 
-        public decimal Width { get; set; }
+        public static decimal Width => 48;
 
-        public decimal Height { get; set; }
+        public static decimal Height => 61;
 
         public override void ComposeTree(TreeComposer composer)
         {
@@ -30,8 +28,8 @@ namespace SmallBasic.Editor.Libraries.Graphics
                 {
                     { "href", $"Turtle.svg" },
                     /* width and height attributes required on Firefox */
-                    { "width", this.Width.ToString(CultureInfo.CurrentCulture) },
-                    { "height", this.Height.ToString(CultureInfo.CurrentCulture) }
+                    { "width", Width.ToString(CultureInfo.CurrentCulture) },
+                    { "height", Height.ToString(CultureInfo.CurrentCulture) }
                 });
         }
     }

--- a/Source/SmallBasic.Editor/Libraries/Shapes/TurtleShape.cs
+++ b/Source/SmallBasic.Editor/Libraries/Shapes/TurtleShape.cs
@@ -14,8 +14,8 @@ namespace SmallBasic.Editor.Libraries.Shapes
         {
         }
 
-        public override decimal Height => this.Graphics.Height;
+        public override decimal Height => TurtleGraphicsObject.Height;
 
-        public override decimal Width => this.Graphics.Width;
+        public override decimal Width => TurtleGraphicsObject.Width;
     }
 }

--- a/Source/SmallBasic.Editor/Libraries/Shapes/TurtleShape.cs
+++ b/Source/SmallBasic.Editor/Libraries/Shapes/TurtleShape.cs
@@ -14,8 +14,8 @@ namespace SmallBasic.Editor.Libraries.Shapes
         {
         }
 
-        public override decimal Height => 61;
+        public override decimal Height => this.Graphics.Height;
 
-        public override decimal Width => 48;
+        public override decimal Width => this.Graphics.Width;
     }
 }


### PR DESCRIPTION
Related to #14. Firefox seems to require explicitly setting the `width` and `height` attributes to show the turtle image. This doesn't fix the problem for MS Edge, however.