### PR TITLE
fixed improper wrapping in Monaco hovers

### DIFF
--- a/Source/SmallBasic.Editor/Components/Toolbox/MonacoEditor.scss
+++ b/Source/SmallBasic.Editor/Components/Toolbox/MonacoEditor.scss
@@ -9,6 +9,11 @@
     position: absolute;
 
     editor {
+        
+        .monaco-editor-hover .monaco-tokenized-source {
+            word-break: normal;
+        }
+        
         .wavy-line {
             display: inline-block;
             position: relative;


### PR DESCRIPTION
As discussed in [issue 55](https://github.com/sb/smallbasic-editor/issues/55) this commit should fix the improper wrapping in the Monaco editors.

Closes #55