### PR TITLE
Implementing Error Badges for Deprecated Libraries

### DIFF
--- a/Source/SmallBasic.Compiler/Runtime/Libraries/Libraries.Generated.cs
+++ b/Source/SmallBasic.Compiler/Runtime/Libraries/Libraries.Generated.cs
@@ -100,9 +100,9 @@ namespace SmallBasic.Compiler.Runtime
 
         public IReadOnlyDictionary<string, Parameter> Parameters { get; private set; }
 
-        internal bool IsDeprecated { get; private set; }
+        public bool IsDeprecated { get; private set; }
 
-        internal bool NeedsDesktop { get; private set; }
+        public bool NeedsDesktop { get; private set; }
 
         internal DExecuteLibraryMember Execute { get; private set; }
     }
@@ -129,9 +129,9 @@ namespace SmallBasic.Compiler.Runtime
 
         public string Description { get; private set; }
 
-        internal bool IsDeprecated { get; private set; }
+        public bool IsDeprecated { get; private set; }
 
-        internal bool NeedsDesktop { get; private set; }
+        public bool NeedsDesktop { get; private set; }
 
         internal DExecuteLibraryMember Getter { get; private set; }
 

--- a/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.cs
+++ b/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.cs
@@ -81,9 +81,13 @@ namespace SmallBasic.Editor.Components.Pages.Edit
                                     composer.Element("caret");
                                     composer.Element("name", body: () => composer.Text($"{this.Library.Name}.{property.Name}"));
 
-                                    if (property.IsDeprecated || property.NeedsDesktop)
+                                    if (property.IsDeprecated)
                                     {
                                         composer.Element("error-corner-ribbon", body: () => composer.Text("Deprecated"));
+                                    }
+                                    else if (property.NeedsDesktop)
+                                    {
+                                        composer.Element("error-corner-ribbon-blue", body: () => composer.Text("Desktop Only"));
                                     }
                                 });
 
@@ -181,9 +185,13 @@ namespace SmallBasic.Editor.Components.Pages.Edit
 
                                 composer.Element("name", body: () => composer.Text($"{this.Library.Name}.{this.Method.Name}()"));
 
-                                if (this.Method.IsDeprecated || this.Method.NeedsDesktop)
+                                if (this.Method.IsDeprecated)
                                 {
                                     composer.Element("error-corner-ribbon", body: () => composer.Text("Deprecated"));
+                                }
+                                else if (this.Method.NeedsDesktop)
+                                {
+                                    composer.Element("error-corner-ribbon-blue", body: () => composer.Text("Desktop Only"));
                                 }
                             });
 

--- a/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.cs
+++ b/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.cs
@@ -80,6 +80,10 @@ namespace SmallBasic.Editor.Components.Pages.Edit
                                 {
                                     composer.Element("caret");
                                     composer.Element("name", body: () => composer.Text($"{this.Library.Name}.{property.Name}"));
+                                    if (property.IsDeprecated || property.NeedsDesktop)
+                                    {
+                                        composer.Element("error-icon-red");
+                                    }
                                 });
 
                                 composer.Element("member-description", body: () => composer.Text(property.Description));
@@ -175,6 +179,11 @@ namespace SmallBasic.Editor.Components.Pages.Edit
                                 });
 
                                 composer.Element("name", body: () => composer.Text($"{this.Library.Name}.{this.Method.Name}()"));
+
+                                if (this.Method.IsDeprecated || this.Method.NeedsDesktop)
+                                {
+                                    composer.Element("error-icon-red");
+                                }
                             });
 
                             composer.Element("member-description", body: () => composer.Text(this.Method.Description));

--- a/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.cs
+++ b/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.cs
@@ -83,7 +83,7 @@ namespace SmallBasic.Editor.Components.Pages.Edit
 
                                     if (property.IsDeprecated || property.NeedsDesktop)
                                     {
-                                        composer.Element("corner-ribbon");
+                                        composer.Element("error-corner-ribbon", body: () => composer.Text("Deprecated"));
                                     }
                                 });
 
@@ -180,14 +180,14 @@ namespace SmallBasic.Editor.Components.Pages.Edit
                                 });
 
                                 composer.Element("name", body: () => composer.Text($"{this.Library.Name}.{this.Method.Name}()"));
+
+                                if (this.Method.IsDeprecated || this.Method.NeedsDesktop)
+                                {
+                                    composer.Element("error-corner-ribbon", body: () => composer.Text("Deprecated"));
+                                }
                             });
 
                             composer.Element("member-description", body: () => composer.Text(this.Method.Description));
-
-                            if (this.Method.IsDeprecated || this.Method.NeedsDesktop)
-                            {
-                                composer.Element("error-corner-ribbon", body: () => composer.Text("Depricated Member"));
-                            }
                         });
 
                     if (this.IsSelected)

--- a/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.cs
+++ b/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.cs
@@ -80,9 +80,10 @@ namespace SmallBasic.Editor.Components.Pages.Edit
                                 {
                                     composer.Element("caret");
                                     composer.Element("name", body: () => composer.Text($"{this.Library.Name}.{property.Name}"));
+
                                     if (property.IsDeprecated || property.NeedsDesktop)
                                     {
-                                        composer.Element("error-icon-red");
+                                        composer.Element("corner-ribbon");
                                     }
                                 });
 
@@ -179,14 +180,14 @@ namespace SmallBasic.Editor.Components.Pages.Edit
                                 });
 
                                 composer.Element("name", body: () => composer.Text($"{this.Library.Name}.{this.Method.Name}()"));
-
-                                if (this.Method.IsDeprecated || this.Method.NeedsDesktop)
-                                {
-                                    composer.Element("error-icon-red");
-                                }
                             });
 
                             composer.Element("member-description", body: () => composer.Text(this.Method.Description));
+
+                            if (this.Method.IsDeprecated || this.Method.NeedsDesktop)
+                            {
+                                composer.Element("error-corner-ribbon", body: () => composer.Text("Depricated Member"));
+                            }
                         });
 
                     if (this.IsSelected)

--- a/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.scss
+++ b/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.scss
@@ -91,6 +91,7 @@ library-body {
             padding-right: 10px;
             box-sizing: border-box;
             cursor: pointer;
+            overflow: hidden;
 
             member-title {
                 display: flex;
@@ -112,30 +113,34 @@ library-body {
                 name {
                     margin-left: 10px;
                 }
+
+                error-corner-ribbon {
+                    position: relative;
+                    display: block;
+                    flex-shrink: 0;
+                    width: 120px;
+                    background: #3b3b3b;
+                    margin-top: 5px;
+                    margin-right: -35px;
+                    margin-left: auto;
+                    transform: rotate(45deg);
+                    -webkit-transform: rotate(45deg);
+                    text-align: center;
+                    font-size: 12px;
+                    font-weight: 300;
+                    letter-spacing: 1px;
+                    color: #f0f0f0;
+                    z-index: 2147483647; // topmost possible z-index value
+                }
             }
 
             member-description {
+                position: relative;
                 flex-shrink: 0;
                 font-size: 12px;
                 padding-left: 20px;
                 padding-bottom: 16px;
                 box-sizing: border-box;
-            }
-
-            error-corner-ribbon {
-                width: 200px;
-                background: #e43;
-                margin-top: 25px;
-                margin-right: -50px;
-                margin-left: auto;
-                transform: rotate(45deg);
-                -webkit-transform: rotate(45deg);
-                text-align: center;
-                line-height: 50px;
-                letter-spacing: 1px;
-                color: #f0f0f0;
-                transform: rotate(-45deg);
-                -webkit-transform: rotate(-45deg);
             }
         }
 

--- a/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.scss
+++ b/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.scss
@@ -126,11 +126,16 @@ library-body {
                     transform: rotate(45deg);
                     -webkit-transform: rotate(45deg);
                     text-align: center;
-                    font-size: 12px;
+                    font-size: 11px;
                     font-weight: 300;
                     letter-spacing: 1px;
                     color: #f0f0f0;
                     z-index: 2147483647; // topmost possible z-index value
+                }
+
+                error-corner-ribbon-blue {
+                    @extend error-corner-ribbon;
+                    background: #0E9DDF;
                 }
             }
 

--- a/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.scss
+++ b/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.scss
@@ -112,11 +112,6 @@ library-body {
                 name {
                     margin-left: 10px;
                 }
-
-                error-icon-red {
-                    margin-left: 30px;
-                    @include set-background-image("EditPage/Error.svg", 15px, 15px);
-                }
             }
 
             member-description {
@@ -125,6 +120,22 @@ library-body {
                 padding-left: 20px;
                 padding-bottom: 16px;
                 box-sizing: border-box;
+            }
+
+            error-corner-ribbon {
+                width: 200px;
+                background: #e43;
+                margin-top: 25px;
+                margin-right: -50px;
+                margin-left: auto;
+                transform: rotate(45deg);
+                -webkit-transform: rotate(45deg);
+                text-align: center;
+                line-height: 50px;
+                letter-spacing: 1px;
+                color: #f0f0f0;
+                transform: rotate(-45deg);
+                -webkit-transform: rotate(-45deg);
             }
         }
 

--- a/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.scss
+++ b/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryBody.scss
@@ -112,6 +112,11 @@ library-body {
                 name {
                     margin-left: 10px;
                 }
+
+                error-icon-red {
+                    margin-left: 30px;
+                    @include set-background-image("EditPage/Error.svg", 15px, 15px);
+                }
             }
 
             member-description {

--- a/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryExplorer.cs
+++ b/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryExplorer.cs
@@ -107,8 +107,44 @@ namespace SmallBasic.Editor.Components.Pages.Edit
                                             composer.Element(
                                                 name: library.Name.Length > 10 ? "long-name" : "short-name",
                                                 body: () => composer.Text(library.Name));
+
+                                            bool hasFunctioningParts = false;
+                                            bool hasNonFunctioningParts = false;
+
+                                            foreach (var property in library.Properties)
+                                            {
+                                                if (property.Value.IsDeprecated || property.Value.NeedsDesktop)
+                                                {
+                                                    hasNonFunctioningParts |= true;
+                                                }
+                                                else
+                                                {
+                                                    hasFunctioningParts |= true;
+                                                }
+                                            }
+
+                                            foreach (var method in library.Methods)
+                                            {
+                                                if (method.Value.IsDeprecated || method.Value.NeedsDesktop)
+                                                {
+                                                    hasNonFunctioningParts |= true;
+                                                }
+                                                else
+                                                {
+                                                    hasFunctioningParts |= true;
+                                                }
+                                            }
+
+                                            if (hasFunctioningParts && hasNonFunctioningParts)
+                                            {
+                                                composer.Element("error-icon-gray", body: () => Micro.FontAwesome(composer, "exclamation-circle"));
+                                            }
+                                            else if (hasNonFunctioningParts)
+                                            {
+                                                composer.Element("error-icon-red");
+                                            }
                                         });
-                                }
+                                  }
                             });
                     });
 

--- a/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryExplorer.cs
+++ b/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryExplorer.cs
@@ -107,42 +107,6 @@ namespace SmallBasic.Editor.Components.Pages.Edit
                                             composer.Element(
                                                 name: library.Name.Length > 10 ? "long-name" : "short-name",
                                                 body: () => composer.Text(library.Name));
-
-                                            bool hasFunctioningParts = false;
-                                            bool hasNonFunctioningParts = false;
-
-                                            foreach (var property in library.Properties)
-                                            {
-                                                if (property.Value.IsDeprecated || property.Value.NeedsDesktop)
-                                                {
-                                                    hasNonFunctioningParts |= true;
-                                                }
-                                                else
-                                                {
-                                                    hasFunctioningParts |= true;
-                                                }
-                                            }
-
-                                            foreach (var method in library.Methods)
-                                            {
-                                                if (method.Value.IsDeprecated || method.Value.NeedsDesktop)
-                                                {
-                                                    hasNonFunctioningParts |= true;
-                                                }
-                                                else
-                                                {
-                                                    hasFunctioningParts |= true;
-                                                }
-                                            }
-
-                                            if (hasFunctioningParts && hasNonFunctioningParts)
-                                            {
-                                                composer.Element("error-icon-gray", body: () => Micro.FontAwesome(composer, "exclamation-circle"));
-                                            }
-                                            else if (hasNonFunctioningParts)
-                                            {
-                                                composer.Element("error-icon-red");
-                                            }
                                         });
                                   }
                             });

--- a/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryExplorer.scss
+++ b/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryExplorer.scss
@@ -98,19 +98,6 @@ library-explorer {
                         margin-top: 19px;
                     }
 
-                    error-icon-red {
-                        position: absolute;
-                        margin-left: 10px;
-                        margin-top: 10px;
-                        @include set-background-image("EditPage/Error.svg", 18px, 18px);
-                    }
-
-                    error-icon-gray {
-                        position: absolute;
-                        margin-left: 10px;
-                        margin-top: 10px;
-                    }
-
                     base-name {
                         margin-bottom: 11px;
                     }

--- a/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryExplorer.scss
+++ b/Source/SmallBasic.Editor/Components/Pages/Edit/LibraryExplorer.scss
@@ -71,6 +71,7 @@ library-explorer {
             align-items: center;
             height: 100%;
             background-color: #BABEC4;
+            position: relative;
             overflow: hidden;
             width: $navigation-area-width;
 
@@ -95,6 +96,19 @@ library-explorer {
                         width: 25px;
                         height: 25px;
                         margin-top: 19px;
+                    }
+
+                    error-icon-red {
+                        position: absolute;
+                        margin-left: 10px;
+                        margin-top: 10px;
+                        @include set-background-image("EditPage/Error.svg", 18px, 18px);
+                    }
+
+                    error-icon-gray {
+                        position: absolute;
+                        margin-left: 10px;
+                        margin-top: 10px;
                     }
 
                     base-name {

--- a/Source/SmallBasic.Generators/Libraries/GenerateLibraries.cs
+++ b/Source/SmallBasic.Generators/Libraries/GenerateLibraries.cs
@@ -56,16 +56,16 @@ namespace SmallBasic.Generators.Scanning
                 ("public", "bool", "ReturnsValue"),
                 ("public", "string", "ReturnValueDescription"),
                 ("public", "IReadOnlyDictionary<string, Parameter>", "Parameters"),
-                ("internal", "bool", "IsDeprecated"),
-                ("internal", "bool", "NeedsDesktop"),
+                ("public", "bool", "IsDeprecated"),
+                ("public", "bool", "NeedsDesktop"),
                 ("internal", "DExecuteLibraryMember", "Execute"));
 
             generateType(
                 "Property",
                 ("public", "string", "Name"),
                 ("public", "string", "Description"),
-                ("internal", "bool", "IsDeprecated"),
-                ("internal", "bool", "NeedsDesktop"),
+                ("public", "bool", "IsDeprecated"),
+                ("public", "bool", "NeedsDesktop"),
                 ("internal", "DExecuteLibraryMember", "Getter"),
                 ("internal", "DExecuteLibraryMember", "Setter"));
 


### PR DESCRIPTION
Fixed # 76. I added error badges to the menu of libraries. I made red badges for libraries with only deprecated and desktop only methods and properties and gray badges for libraries that have some deprecated or desktop only functions and some functioning ones. I also made individual red badges for the methods and properties that are errors themselves. Below is a brief summarizing list of the changes that were made in all the files. 

SmallBasic.Generators/Libraries/GenerateLibraries.cs
- Made some methods in methods and properties public rather than internal to allow classification of methods as needing desktop or being deprecated in the library menu from SmallBasic.Editor. 

SmallBasic.Compiler/Runtime/Libraries/Libraries.Generated.cs (not necessary because of generated stuff)
- Made some methods in methods and properties public to allow classification of methods as needing desktop or being deprecated in the library menu from SmallBasic.Editor. 

SmallBasic.Editor/Components/Pages/Edit/LibraryExplorer.cs
- Added in code in the processing of libraries to check whether libraries have methods or properties that need desktop or are deprecated.
- Libraries that have all properties and methods either needing desktop or being deprecated are marked with a red badge while those with only some needing desktop or being deprecated are marked with a gray badge. 

SmallBasic.Editor/Components/Pages/Edit/LibraryExplorer.scss
- Added in the gray and red badges. 

SmallBasic.Editor/Components/Pages/Edit/LibraryBody.cs
- Added in code in the processing of properties and methods to check whether they need desktop or are deprecated. Adds a display of a red badge if that's the case.

SmallBasic.Editor/Components/Pages/Edit/LibraryBody.scss
- Added in the red badge. 

Closes #4