### PR TITLE
Fix Shapes.Zoom causing program to hang

### DIFF
--- a/Source/SmallBasic.Editor/Libraries/Shapes/BaseShape.cs
+++ b/Source/SmallBasic.Editor/Libraries/Shapes/BaseShape.cs
@@ -170,11 +170,6 @@ namespace SmallBasic.Editor.Libraries.Shapes
 
         private Action AttachScale(Action body, TreeComposer composer)
         {
-            if (this.ScaleX == 1 && this.ScaleY == 1)
-            {
-                return body;
-            }
-
             return () =>
             {
                 composer.Element(


### PR DESCRIPTION
I noticed that calling Shapes.Zoom(shape, 1, 1) only had an error after the shape had been zoomed to another scale first (i.e. only ever calling Zoom(shape, 1, 1) or never calling Zoom(shape, 1, 1) executed fine). 

Removing this special case seems to fix the issue as the code given by @nonkit in #89 runs without errors. @nonkit can you confirm that the output of the program is as expected? 