### PR TITLE
Fix Shapes.Rotate causing program to hang

### DIFF
--- a/Source/SmallBasic.Editor/Libraries/Shapes/BaseShape.cs
+++ b/Source/SmallBasic.Editor/Libraries/Shapes/BaseShape.cs
@@ -124,11 +124,6 @@ namespace SmallBasic.Editor.Libraries.Shapes
 
         private Action AttachRotation(Action body, TreeComposer composer)
         {
-            if (this.Angle == 0 && !this.AngleAnimation.HasValue)
-            {
-                return body;
-            }
-
             return () =>
             {
                 composer.Element(


### PR DESCRIPTION
Similar to #96, there is a special case for when the angle is 0 (which is true when our angle is 360 because the angle is simplified elsewhere to the number of degrees % 360) that is causing this to break. It seems like this was an optimization made at some point that only causes issues when the rotation to 360 comes after a rotation to another angle. It appears removing this special case fixes the issue in #92. @nonkit, can you confirm?