### PR TITLE
Fix problem loading image for GraphicsWindow.DrawImage

### DIFF
--- a/Source/SmallBasic.Editor/Libraries/Graphics/ImageGraphicsObject.cs
+++ b/Source/SmallBasic.Editor/Libraries/Graphics/ImageGraphicsObject.cs
@@ -34,10 +34,10 @@ namespace SmallBasic.Editor.Libraries.Graphics
         public override void ComposeTree(TreeComposer composer)
         {
             composer.Element(
-                name: "use",
+                name: "image",
                 attributes: new Dictionary<string, string>
                 {
-                    { "href", $"#{this.Name}" },
+                    { "href", this.Name },
                     { "x", this.X.ToString(CultureInfo.CurrentCulture) },
                     { "y", this.Y.ToString(CultureInfo.CurrentCulture) },
                     { "transform", $"scale({this.ScaleX}, {this.ScaleY})" }


### PR DESCRIPTION
Fix the issue #58 of failing to load external image with `GraphicsWindow.DrawImage`. The problem was that the SVG "use" element is usually meant to load from within the SVG document, and external URLs are not supported for some browsers: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use. Switching to "image" element and referring directly to the image URL fixed the issue.