### PR TITLE
Allow submodules to share names with variables when possible (backcompat)

### DIFF
--- a/Source/SmallBasic.Compiler/Binding/Binder.cs
+++ b/Source/SmallBasic.Compiler/Binding/Binder.cs
@@ -546,8 +546,7 @@ namespace SmallBasic.Compiler.Binding
             {
                 if (expectsValue)
                 {
-                    hasErrors = true;
-                    this.diagnostics.ReportExpectedExpressionWithAValue(syntax.Range);
+                    return new BoundVariableExpression(syntax, hasValue: true, hasErrors, name);
                 }
 
                 return new BoundSubModuleExpression(syntax, hasValue: false, hasErrors, name);

--- a/Source/SmallBasic.Tests/Compiler/BindingTests.cs
+++ b/Source/SmallBasic.Tests/Compiler/BindingTests.cs
@@ -15,8 +15,7 @@ namespace SmallBasic.Tests.Compiler
         [Fact]
         public void CallingNonexistentSubroutine()
         {
-            new SmallBasicCompilation(@"
-            test()").VerifyDiagnostics(
+            new SmallBasicCompilation("test()").VerifyDiagnostics(
             // test()
             // ^^^^^^
             // This expression is not a valid submodule or method to be called.

--- a/Source/SmallBasic.Tests/Compiler/BindingTests.cs
+++ b/Source/SmallBasic.Tests/Compiler/BindingTests.cs
@@ -15,9 +15,8 @@ namespace SmallBasic.Tests.Compiler
         [Fact]
         public void CallingNonexistentSubroutine()
         {
-            new SmallBasicCompilation(
-                @"test()"
-            ).VerifyDiagnostics(
+            new SmallBasicCompilation(@"
+            test()").VerifyDiagnostics(
             // test()
             // ^^^^^^
             // This expression is not a valid submodule or method to be called.

--- a/Source/SmallBasic.Tests/Compiler/BindingTests.cs
+++ b/Source/SmallBasic.Tests/Compiler/BindingTests.cs
@@ -13,6 +13,18 @@ namespace SmallBasic.Tests.Compiler
     public sealed class BindingTests : IClassFixture<CultureFixture>
     {
         [Fact]
+        public void CallingNonexistentSubroutine()
+        {
+            new SmallBasicCompilation(
+                @"test()"
+            ).VerifyDiagnostics(
+            // test()
+            // ^^^^^^
+            // This expression is not a valid submodule or method to be called.
+            new Diagnostic(DiagnosticCode.UnsupportedInvocationBaseExpression, ((0, 0), (0, 5))));
+        }
+
+        [Fact]
         public void ItReportsInForLoopFromExpression()
         {
             new SmallBasicCompilation(@"
@@ -439,19 +451,6 @@ TextWindow.WriteLine = 5").VerifyDiagnostics(
                 // ^^^^^^^^^^^^^^^^^^^^
                 // This expression must have a value to be used here.
                 new Diagnostic(DiagnosticCode.ExpectedExpressionWithAValue, ((1, 0), (1, 19))));
-        }
-
-        [Fact]
-        public void ItReportsAssigningToSubModule()
-        {
-            new SmallBasicCompilation(@"
-Sub x
-EndSub
-x = 5").VerifyDiagnostics(
-                // x = 5
-                // ^
-                // This expression must have a value to be used here.
-                new Diagnostic(DiagnosticCode.ExpectedExpressionWithAValue, ((3, 0), (3, 0))));
         }
 
         [Fact]

--- a/Source/SmallBasic.Tests/Runtime/StatementsTests.cs
+++ b/Source/SmallBasic.Tests/Runtime/StatementsTests.cs
@@ -29,7 +29,8 @@ TextWindow.WriteLine(data: '5')
         public Task SubroutineAndLabelSameName()
         {
             return new SmallBasicCompilation(
-            @"for i = 1 to 5
+            @"
+for i = 1 to 5
 If (i > 4) Then
 GoTo test
 EndIf       

--- a/Source/SmallBasic.Tests/Runtime/StatementsTests.cs
+++ b/Source/SmallBasic.Tests/Runtime/StatementsTests.cs
@@ -28,19 +28,18 @@ TextWindow.WriteLine(data: '5')
         [Fact]
         public Task SubroutineAndLabelSameName()
         {
-            return new SmallBasicCompilation(
-            @"
+            return new SmallBasicCompilation(@"
 for i = 1 to 5
-If (i > 4) Then
-GoTo test
-EndIf       
-test()
+    If (i > 4) Then
+        GoTo test
+    EndIf       
+    test()
 EndFor
 
 test:
 
 Sub test
-TextWindow.WriteLine(""Hello World!"")
+    TextWindow.WriteLine(""Hello World!"")
 EndSub").VerifyLoggingRuntime(@"
 TextWindow.WriteLine(data: 'Hello World!')
 TextWindow.WriteLine(data: 'Hello World!')
@@ -52,15 +51,15 @@ TextWindow.WriteLine(data: 'Hello World!')
         [Fact]
         public Task SubroutineAndForLoopVariableSameName()
         {
-            return new SmallBasicCompilation(
-            @"test()
+            return new SmallBasicCompilation(@"
+test()
 for test = 1 to 3
-TextWindow.WriteLine(test)
+    TextWindow.WriteLine(test)
 EndFor
 
 test()
 Sub test
-TextWindow.WriteLine(""Hello World!"")
+    TextWindow.WriteLine(""Hello World!"")
 EndSub
 test()
  ").VerifyLoggingRuntime(expectedLog: @"

--- a/Source/SmallBasic.Tests/Runtime/StatementsTests.cs
+++ b/Source/SmallBasic.Tests/Runtime/StatementsTests.cs
@@ -10,6 +10,68 @@ namespace SmallBasic.Tests.Runtime
 
     public sealed class StatementsTests : IClassFixture<CultureFixture>
     {
+        // https://github.com/sb/smallbasic-editor/issues/71
+        [Fact]
+        public Task ItReportsAssigningToSubmodule()
+        {
+            return new SmallBasicCompilation(
+            @"
+Sub x
+EndSub
+x = 5
+TextWindow.WriteLine(x)").VerifyLoggingRuntime(@"
+TextWindow.WriteLine(data: '5')
+");
+        }
+
+        // https://github.com/sb/smallbasic-editor/issues/71
+        [Fact]
+        public Task SubroutineAndLabelSameName()
+        {
+            return new SmallBasicCompilation(
+            @"for i = 1 to 5
+If (i > 4) Then
+GoTo test
+EndIf       
+test()
+EndFor
+
+test:
+
+Sub test
+TextWindow.WriteLine(""Hello World!"")
+EndSub").VerifyLoggingRuntime(@"
+TextWindow.WriteLine(data: 'Hello World!')
+TextWindow.WriteLine(data: 'Hello World!')
+TextWindow.WriteLine(data: 'Hello World!')
+TextWindow.WriteLine(data: 'Hello World!')
+");
+        }
+
+        [Fact]
+        public Task SubroutineAndForLoopVariableSameName()
+        {
+            return new SmallBasicCompilation(
+            @"test()
+for test = 1 to 3
+TextWindow.WriteLine(test)
+EndFor
+
+test()
+Sub test
+TextWindow.WriteLine(""Hello World!"")
+EndSub
+test()
+ ").VerifyLoggingRuntime(expectedLog: @"
+TextWindow.WriteLine(data: 'Hello World!')
+TextWindow.WriteLine(data: '1')
+TextWindow.WriteLine(data: '2')
+TextWindow.WriteLine(data: '3')
+TextWindow.WriteLine(data: 'Hello World!')
+TextWindow.WriteLine(data: 'Hello World!')
+");
+        }
+
         [Fact]
         public Task ItEvaluatesSingleIfTrueExpression()
         {


### PR DESCRIPTION
Fixes #71
Replaces #91
