### PR TITLE
Support alpha component in hex colors

### DIFF
--- a/Source/SmallBasic.Editor/Libraries/GraphicsWindowLibrary.cs
+++ b/Source/SmallBasic.Editor/Libraries/GraphicsWindowLibrary.cs
@@ -24,7 +24,7 @@ namespace SmallBasic.Editor.Libraries
         private readonly List<BaseGraphicsObject> graphics = new List<BaseGraphicsObject>();
 
         private static readonly Random RandomInstance = new Random((int)DateTime.Now.Ticks);
-        private static readonly Regex HexColorRegex = new Regex("^#[0-9A-Fa-f]{6}$");
+        private static readonly Regex HexColorRegex = new Regex("^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$");
         private static readonly IReadOnlyList<string> PredefinedFonts = new List<string>
         {
             "Roboto",


### PR DESCRIPTION
Not sure if this has a final decision yet (discussion in #57). This PR implements the simplest solution (going with web standards) that is consistent with v.0.91, but breaks compability to SBD (also see [#44 comment](https://github.com/sb/smallbasic-editor/issues/44#issuecomment-468829317)) as this seems to be the way to go.

Here's @ozjerry's drawing from #57:
![grafik](https://user-images.githubusercontent.com/26907770/66763750-b3cd3f80-eea8-11e9-8cfc-b781496559ae.png)
