### PR TITLE
Fix GraphicsWindow keyboard events

### DIFF
--- a/Source/SmallBasic.Client/Interop/CSInterop.Generated.ts
+++ b/Source/SmallBasic.Client/Interop/CSInterop.Generated.ts
@@ -29,5 +29,17 @@ export module CSIntrop {
                 Promise.resolve();
             });
         }
+
+        export function onKeyUp(key: string): Promise<void> {
+            return DotNet.invokeMethodAsync<boolean>("SmallBasic.Editor", "CSIntrop.GraphicsDisplay.OnKeyUp", key).then(() => {
+                Promise.resolve();
+            });
+        }
+
+        export function onKeyDown(key: string): Promise<void> {
+            return DotNet.invokeMethodAsync<boolean>("SmallBasic.Editor", "CSIntrop.GraphicsDisplay.OnKeyDown", key).then(() => {
+                Promise.resolve();
+            });
+        }
     }
 }

--- a/Source/SmallBasic.Client/Utility/GraphicsDisplay.ts
+++ b/Source/SmallBasic.Client/Utility/GraphicsDisplay.ts
@@ -2,21 +2,48 @@
  * Licensed under the MIT License. See LICENSE file in the project root for license information.
  */
 
+import * as $ from "jquery";
 import { CSIntrop } from "../Interop/CSInterop.Generated";
-
-setInterval(checkForDisplay, 100);
 
 let lastUpdatedX = 0;
 let lastUpdatedY = 0;
 
-function checkForDisplay(): void {
-    const displays = document.getElementsByTagName("graphics-display");
-    if (displays.length === 1) {
-        const rect = displays.item(0).getBoundingClientRect();
-        if (rect.left !== lastUpdatedX || rect.top !== lastUpdatedY) {
-            lastUpdatedX = rect.left;
-            lastUpdatedY = rect.top;
-            CSIntrop.GraphicsDisplay.updateDisplayLocation(lastUpdatedX, lastUpdatedY);
-        }
+$(window).resize(() => {
+    const display = getGraphicsDisplay();
+    if (display === null) {
+        return;
     }
+
+    const rect = display.getBoundingClientRect();
+    if (rect.left !== lastUpdatedX || rect.top !== lastUpdatedY) {
+        lastUpdatedX = rect.left;
+        lastUpdatedY = rect.top;
+        CSIntrop.GraphicsDisplay.updateDisplayLocation(lastUpdatedX, lastUpdatedY);
+    }
+});
+
+const CHECK_INTERVAL = 250;
+
+setInterval(() => {
+    const display = getGraphicsDisplay();
+    if (display === null) {
+        return;
+    }
+
+    const stamp = "x-display-key-events-done";
+    if (display.hasAttribute(stamp)) {
+        return;
+    }
+
+    $(display).keyup(e => {
+        CSIntrop.GraphicsDisplay.onKeyUp(e.key);
+    }).keydown(e => {
+        CSIntrop.GraphicsDisplay.onKeyDown(e.key);
+    });
+
+    display.setAttribute(stamp, "true");
+}, CHECK_INTERVAL);
+
+function getGraphicsDisplay(): Element | null {
+    return document.getElementsByTagName("graphics-display").item(0);
 }

--- a/Source/SmallBasic.Client/package-lock.json
+++ b/Source/SmallBasic.Client/package-lock.json
@@ -155,6 +155,15 @@
         "@types/webpack": "*"
       }
     },
+    "@types/jquery": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.0.tgz",
+      "integrity": "sha512-C7qQUjpMWDUNYQRTXsP5nbYYwCwwgy84yPgoTT7fPN69NH92wLeCtFaMsWeolJD1AF/6uQw3pYt62rzv83sMmw==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
     "@types/mini-css-extract-plugin": {
       "version": "0.2.0",
       "resolved": "http://registry.npmjs.org/@types/mini-css-extract-plugin/-/mini-css-extract-plugin-0.2.0.tgz",
@@ -180,6 +189,12 @@
       "version": "0.2.28",
       "resolved": "http://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
       "integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y=",
+      "dev": true
+    },
+    "@types/sizzle": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+      "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
       "dev": true
     },
     "@types/tapable": {
@@ -933,8 +948,7 @@
     "boolean": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
-      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
-      "optional": true
+      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1275,8 +1289,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1297,14 +1310,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1319,20 +1330,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1449,8 +1457,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1462,7 +1469,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1477,7 +1483,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -1485,14 +1490,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -1511,7 +1514,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1592,8 +1594,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1605,7 +1606,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -1691,8 +1691,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -1728,7 +1727,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -1748,7 +1746,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -1792,14 +1789,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/Source/SmallBasic.Client/package.json
+++ b/Source/SmallBasic.Client/package.json
@@ -10,6 +10,7 @@
     "@types/element-resize-event": "2.0.0",
     "@types/file-saver": "2.0.0",
     "@types/html-webpack-plugin": "3.2.0",
+    "@types/jquery": "3.5.0",
     "@types/mini-css-extract-plugin": "0.2.0",
     "@types/webpack": "4.4.12",
     "applicationinsights-js": "1.0.20",

--- a/Source/SmallBasic.Editor/Components/Display/GraphicsDisplay.cs
+++ b/Source/SmallBasic.Editor/Components/Display/GraphicsDisplay.cs
@@ -77,8 +77,6 @@ namespace SmallBasic.Editor.Components.Display
                             OnMouseDown = args => GraphicsDisplayStore.NotifyMouseDown(args.ClientX, args.ClientY, GetMouseButton(args.Button)),
                             OnMouseUp = args => GraphicsDisplayStore.NotifyMouseUp(args.ClientX, args.ClientY, GetMouseButton(args.Button)),
                             OnMouseMove = args => GraphicsDisplayStore.NotifyMouseMove(args.ClientX, args.ClientY),
-                            OnKeyDown = args => GraphicsDisplayStore.NotifyKeyDown(args.Key),
-                            OnKeyUp = args => GraphicsDisplayStore.NotifyKeyUp(args.Key),
                         },
                         body: () =>
                         {

--- a/Source/SmallBasic.Editor/Components/TreeComposer.cs
+++ b/Source/SmallBasic.Editor/Components/TreeComposer.cs
@@ -104,11 +104,7 @@ namespace SmallBasic.Editor.Components
 
             public Func<UIWheelEventArgs, Task> OnMouseWheelAsync { get; set; }
 
-            public Action<UIKeyboardEventArgs> OnKeyDown { get; set; }
-
             public Func<UIKeyboardEventArgs, Task> OnKeyDownAsync { get; set; }
-
-            public Action<UIKeyboardEventArgs> OnKeyUp { get; set; }
 
             public Action<UIMouseEventArgs> OnMouseDown { get; set; }
 
@@ -140,21 +136,9 @@ namespace SmallBasic.Editor.Components
                     composer.builder.AddAttribute(composer.sequence++, "onmousewheel", BindMethods.GetEventHandlerValue(this.OnMouseWheelAsync));
                 }
 
-                if (!this.OnKeyDown.IsDefault())
-                {
-                    Debug.Assert(this.OnKeyDownAsync.IsDefault(), "Cannot set both sync and async versions of this event");
-                    composer.builder.AddAttribute(composer.sequence++, "onkeydown", BindMethods.GetEventHandlerValue(this.OnKeyDown));
-                }
-
                 if (!this.OnKeyDownAsync.IsDefault())
                 {
-                    Debug.Assert(this.OnKeyDown.IsDefault(), "Cannot set both sync and async versions of this event");
                     composer.builder.AddAttribute(composer.sequence++, "onkeydown", BindMethods.GetEventHandlerValue(this.OnKeyDownAsync));
-                }
-
-                if (!this.OnKeyUp.IsDefault())
-                {
-                    composer.builder.AddAttribute(composer.sequence++, "onkeyup", BindMethods.GetEventHandlerValue(this.OnKeyUp));
                 }
 
                 if (!this.OnMouseDown.IsDefault())

--- a/Source/SmallBasic.Editor/Interop/CSInterop.Generated.cs
+++ b/Source/SmallBasic.Editor/Interop/CSInterop.Generated.cs
@@ -23,6 +23,10 @@ namespace SmallBasic.Editor.Interop
     internal interface IGraphicsDisplayInterop
     {
         Task UpdateDisplayLocation(decimal x, decimal y);
+
+        Task OnKeyUp(string key);
+
+        Task OnKeyDown(string key);
     }
 
     public static class CSInterop
@@ -53,6 +57,20 @@ namespace SmallBasic.Editor.Interop
         public static async Task<bool> GraphicsDisplay_UpdateDisplayLocation(decimal x, decimal y)
         {
             await GraphicsDisplay.UpdateDisplayLocation(x, y).ConfigureAwait(false);
+            return true;
+        }
+
+        [JSInvokable("CSIntrop.GraphicsDisplay.OnKeyUp")]
+        public static async Task<bool> GraphicsDisplay_OnKeyUp(string key)
+        {
+            await GraphicsDisplay.OnKeyUp(key).ConfigureAwait(false);
+            return true;
+        }
+
+        [JSInvokable("CSIntrop.GraphicsDisplay.OnKeyDown")]
+        public static async Task<bool> GraphicsDisplay_OnKeyDown(string key)
+        {
+            await GraphicsDisplay.OnKeyDown(key).ConfigureAwait(false);
             return true;
         }
     }

--- a/Source/SmallBasic.Editor/Interop/GraphicsDisplayInterop.cs
+++ b/Source/SmallBasic.Editor/Interop/GraphicsDisplayInterop.cs
@@ -14,5 +14,17 @@ namespace SmallBasic.Editor.Interop
             GraphicsDisplayStore.UpdateDisplayLocation(x, y);
             return Task.CompletedTask;
         }
+
+        public Task OnKeyUp(string key)
+        {
+            GraphicsDisplayStore.NotifyKeyUp(key);
+            return Task.CompletedTask;
+        }
+
+        public Task OnKeyDown(string key)
+        {
+            GraphicsDisplayStore.NotifyKeyDown(key);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/Source/SmallBasic.Generators/Interop/CSInteropTypes.xml
+++ b/Source/SmallBasic.Generators/Interop/CSInteropTypes.xml
@@ -29,6 +29,16 @@
           <Parameter Name="y" Type="number" />
         </Parameters>
       </Method>
+      <Method Name="OnKeyUp">
+        <Parameters>
+          <Parameter Name="key" Type="string" />
+        </Parameters>
+      </Method>
+      <Method Name="OnKeyDown">
+        <Parameters>
+          <Parameter Name="key" Type="string" />
+        </Parameters>
+      </Method>
     </Methods>
   </InteropType>
 </root>


### PR DESCRIPTION
Bug in existing implementation was using `onkeyup` and `onkeydown` events of an `svg` element, which does not accept input.
This PR moves the event listening to the client side (on the graphics element itself) to fix that.

Tested with the following program:

```
GraphicsWindow.KeyUp = OnKeyUp
GraphicsWindow.KeyDown = OnKeyDown

Sub OnKeyDown
    TextWindow.WriteLine("key down: " + GraphicsWindow.LastKey)
EndSub

Sub OnKeyUp
    TextWindow.WriteLine("key up: " + GraphicsWindow.LastKey)
EndSub
```

Fixes #106
Fixes #112
Fixes #134