### PR TITLE
Implement GraphicsWindow.Title & TextWindow.Title

### DIFF
--- a/Source/SmallBasic.Compiler/Runtime/Libraries/Libraries.Generated.cs
+++ b/Source/SmallBasic.Compiler/Runtime/Libraries/Libraries.Generated.cs
@@ -2461,15 +2461,19 @@ namespace SmallBasic.Compiler.Runtime
                 {
                     Task getter(SmallBasicEngine engine)
                     {
-                        throw new InvalidOperationException("Library property 'GraphicsWindow.Title' is deprecated.");
+                        string value = engine.Libraries.GraphicsWindow.Get_Title();
+                        engine.EvaluationStack.Push(StringValue.Create(value));
+                        return Task.CompletedTask;
                     }
 
                     Task setter(SmallBasicEngine engine)
                     {
-                        throw new InvalidOperationException("Library property 'GraphicsWindow.Title' is deprecated.");
+                        string value = engine.EvaluationStack.Pop().ToString();
+                        engine.Libraries.GraphicsWindow.Set_Title(value);
+                        return Task.CompletedTask;
                     }
 
-                    properties.Add("Title", new Property("Title", LibrariesResources.GraphicsWindow_Title, isDeprecated: true, needsDesktop: false, getter: getter, setter: setter));
+                    properties.Add("Title", new Property("Title", LibrariesResources.GraphicsWindow_Title, isDeprecated: false, needsDesktop: false, getter: getter, setter: setter));
                 }
 
                 // Initialization code for property GraphicsWindow.Top:
@@ -4788,15 +4792,19 @@ namespace SmallBasic.Compiler.Runtime
                 {
                     Task getter(SmallBasicEngine engine)
                     {
-                        throw new InvalidOperationException("Library property 'TextWindow.Title' is deprecated.");
+                        string value = engine.Libraries.TextWindow.Get_Title();
+                        engine.EvaluationStack.Push(StringValue.Create(value));
+                        return Task.CompletedTask;
                     }
 
                     Task setter(SmallBasicEngine engine)
                     {
-                        throw new InvalidOperationException("Library property 'TextWindow.Title' is deprecated.");
+                        string value = engine.EvaluationStack.Pop().ToString();
+                        engine.Libraries.TextWindow.Set_Title(value);
+                        return Task.CompletedTask;
                     }
 
-                    properties.Add("Title", new Property("Title", LibrariesResources.TextWindow_Title, isDeprecated: true, needsDesktop: false, getter: getter, setter: setter));
+                    properties.Add("Title", new Property("Title", LibrariesResources.TextWindow_Title, isDeprecated: false, needsDesktop: false, getter: getter, setter: setter));
                 }
 
                 // Initialization code for property TextWindow.Top:

--- a/Source/SmallBasic.Compiler/Runtime/Libraries/Libraries.Interfaces.Generated.cs
+++ b/Source/SmallBasic.Compiler/Runtime/Libraries/Libraries.Interfaces.Generated.cs
@@ -190,6 +190,10 @@ namespace SmallBasic.Compiler.Runtime
 
         void Set_PenWidth(decimal value);
 
+        string Get_Title();
+
+        void Set_Title(string value);
+
         Task<decimal> Get_Width();
 
         void Clear();
@@ -402,6 +406,10 @@ namespace SmallBasic.Compiler.Runtime
         string Get_ForegroundColor();
 
         void Set_ForegroundColor(string value);
+
+        string Get_Title();
+
+        void Set_Title(string value);
 
         void Clear();
 

--- a/Source/SmallBasic.Editor/Components/Display/GraphicsDisplay.cs
+++ b/Source/SmallBasic.Editor/Components/Display/GraphicsDisplay.cs
@@ -32,6 +32,8 @@ namespace SmallBasic.Editor.Components.Display
 
         public bool IsMouseVisible { get; set; }
 
+        public string Title { get; set; }
+
         [Parameter]
         private LibrariesCollection Libraries { get; set; }
 
@@ -64,6 +66,12 @@ namespace SmallBasic.Editor.Components.Display
                 },
                 body: () =>
                 {
+                    if (!string.IsNullOrEmpty(this.Title))
+                    {
+                        composer.Element(
+                            name: "title",
+                            body: () => composer.Text(this.Title));
+                    }
                     composer.Element(
                         name: "svg",
                         capture: element => this.RenderArea = element,

--- a/Source/SmallBasic.Editor/Components/Display/GraphicsDisplay.scss
+++ b/Source/SmallBasic.Editor/Components/Display/GraphicsDisplay.scss
@@ -11,6 +11,15 @@ graphics-display {
     // Required to have "absolute" positioned children
     position: relative;
 
+    title {
+        display: block;
+        padding: 4px 8px;
+        background: #F3F3F3;
+        border-bottom: 1px solid #656A72;
+        font-family: Roboto, sans-serif;
+        font-size: 16px;
+    }
+
     svg {
         // Needs to have a "relative" parent
         position: absolute;

--- a/Source/SmallBasic.Editor/Components/Display/TextDisplay.cs
+++ b/Source/SmallBasic.Editor/Components/Display/TextDisplay.cs
@@ -36,6 +36,8 @@ namespace SmallBasic.Editor.Components.Display
             TextDisplayStore.SetDisplay(this);
         }
 
+        public string Title { get; set; }
+
         internal async Task AppendOutput(OutputChunk chunk)
         {
             this.outputChunks.Add(chunk);
@@ -93,6 +95,12 @@ namespace SmallBasic.Editor.Components.Display
                 },
                 body: () =>
                 {
+                    if (!string.IsNullOrEmpty(this.Title))
+                    {
+                        composer.Element(
+                            name: "title",
+                            body: () => composer.Text(this.Title));
+                    }
                     foreach (var chunk in this.outputChunks)
                     {
                         composer.Element(

--- a/Source/SmallBasic.Editor/Components/Display/TextDisplay.scss
+++ b/Source/SmallBasic.Editor/Components/Display/TextDisplay.scss
@@ -14,6 +14,16 @@ text-display {
     border: 1px solid #656A72;
     white-space: pre;
 
+    title {
+        display: block;
+        margin: -5px -5px 5px -5px;
+        padding: 4px 8px;
+        background: #F3F3F3;
+        border-bottom: 1px solid #656A72;
+        font-family: Roboto, sans-serif;
+        font-size: 16px;
+    }
+
     input-field {
         color: gray;
         display: inline;

--- a/Source/SmallBasic.Editor/Libraries/GraphicsWindowLibrary.cs
+++ b/Source/SmallBasic.Editor/Libraries/GraphicsWindowLibrary.cs
@@ -191,6 +191,8 @@ namespace SmallBasic.Editor.Libraries
 
         public Task<decimal> Get_Width() => JSInterop.Layout.GetElementWidth(GraphicsDisplayStore.RenderArea);
 
+        public string Get_Title() => GraphicsDisplayStore.Title;
+
         public void Set_BackgroundColor(string value)
         {
             value = value.Trim();
@@ -246,6 +248,8 @@ namespace SmallBasic.Editor.Libraries
         }
 
         public void Set_PenWidth(decimal value) => this.libraries.Styles = this.libraries.Styles.With(penWidth: value);
+
+        public void Set_Title(string value) => GraphicsDisplayStore.Title = value;
 
         public Task ShowMessage(string text, string title) => JSInterop.Layout.ShowMessage(text, title);
 

--- a/Source/SmallBasic.Editor/Libraries/TextWindowLibrary.cs
+++ b/Source/SmallBasic.Editor/Libraries/TextWindowLibrary.cs
@@ -34,6 +34,8 @@ namespace SmallBasic.Editor.Libraries
 
         public string Get_ForegroundColor() => this.foregroundColorName;
 
+        public string Get_Title() => TextDisplayStore.Title;
+
         public string Read() => this.inputBuffer;
 
         public decimal ReadNumber() => decimal.Parse(this.inputBuffer, CultureInfo.CurrentCulture);
@@ -63,6 +65,8 @@ namespace SmallBasic.Editor.Libraries
                 this.foregroundColorName = value;
             }
         }
+
+        public void Set_Title(string value) => TextDisplayStore.Title = value;
 
         public Task Write(string data)
         {

--- a/Source/SmallBasic.Editor/Store/GraphicsDisplayStore.cs
+++ b/Source/SmallBasic.Editor/Store/GraphicsDisplayStore.cs
@@ -68,6 +68,27 @@ namespace SmallBasic.Editor.Store
             }
         }
 
+        public static string Title
+        {
+            get
+            {
+                if (display.IsDefault())
+                {
+                    return string.Empty;
+                }
+
+                return display.Title;
+            }
+
+            set
+            {
+                if (!display.IsDefault())
+                {
+                    display.Title = value;
+                }
+            }
+        }
+
         public static void SetDisplay(GraphicsDisplay instance)
         {
             display = instance;

--- a/Source/SmallBasic.Editor/Store/TextDisplayStore.cs
+++ b/Source/SmallBasic.Editor/Store/TextDisplayStore.cs
@@ -17,6 +17,27 @@ namespace SmallBasic.Editor.Store
 
         public static event TextInputEventSignature TextInput;
 
+        public static string Title
+        {
+            get
+            {
+                if (display.IsDefault())
+                {
+                    return string.Empty;
+                }
+
+                return display.Title;
+            }
+
+            set
+            {
+                if (!display.IsDefault())
+                {
+                    display.Title = value;
+                }
+            }
+        }
+
         public static void SetDisplay(TextDisplay instance)
         {
             display = instance;

--- a/Source/SmallBasic.Generators/Libraries/Libraries.xml
+++ b/Source/SmallBasic.Generators/Libraries/Libraries.xml
@@ -481,7 +481,7 @@
       <Property Name="MouseY" HasGetter="true" HasSetter="false" Type="NumberValue" />
       <Property Name="PenColor" HasGetter="true" HasSetter="true" Type="StringValue" />
       <Property Name="PenWidth" HasGetter="true" HasSetter="true" Type="NumberValue" />
-      <Property Name="Title" HasGetter="true" HasSetter="true" Type="StringValue" IsDeprecated="true" />
+      <Property Name="Title" HasGetter="true" HasSetter="true" Type="StringValue" />
       <Property Name="Top" HasGetter="true" HasSetter="true" Type="NumberValue" IsDeprecated="true" />
       <Property Name="Width" HasGetter="true" HasSetter="false" Type="NumberValue" IsAsync="true" />
     </Properties>
@@ -940,7 +940,7 @@
       <Property Name="CursorTop" HasGetter="true" HasSetter="true" Type="NumberValue" IsDeprecated="true" />
       <Property Name="ForegroundColor" HasGetter="true" HasSetter="true" Type="StringValue" />
       <Property Name="Left" HasGetter="true" HasSetter="true" Type="NumberValue" IsDeprecated="true" />
-      <Property Name="Title" HasGetter="true" HasSetter="true" Type="StringValue" IsDeprecated="true" />
+      <Property Name="Title" HasGetter="true" HasSetter="true" Type="StringValue" />
       <Property Name="Top" HasGetter="true" HasSetter="true" Type="NumberValue" IsDeprecated="true" />
     </Properties>
   </Library>

--- a/Source/SmallBasic.Tests/LoggingTestLibraries.Generated.cs
+++ b/Source/SmallBasic.Tests/LoggingTestLibraries.Generated.cs
@@ -504,6 +504,17 @@ namespace SmallBasic.Tests
             this.log.AppendLine($"GraphicsWindow.Set_PenWidth('{value}')");
         }
 
+        public string Get_Title()
+        {
+            this.log.AppendLine($"GraphicsWindow.Get_Title()");
+            return string.Empty;
+        }
+
+        public void Set_Title(string value)
+        {
+            this.log.AppendLine($"GraphicsWindow.Set_Title('{value}')");
+        }
+
         public Task<decimal> Get_Width()
         {
             this.log.AppendLine($"GraphicsWindow.Get_Width()");
@@ -1118,6 +1129,17 @@ namespace SmallBasic.Tests
         public void Set_ForegroundColor(string value)
         {
             this.log.AppendLine($"TextWindow.Set_ForegroundColor('{value}')");
+        }
+
+        public string Get_Title()
+        {
+            this.log.AppendLine($"TextWindow.Get_Title()");
+            return string.Empty;
+        }
+
+        public void Set_Title(string value)
+        {
+            this.log.AppendLine($"TextWindow.Set_Title('{value}')");
         }
 
         public void Clear()


### PR DESCRIPTION
My take on implementing `GraphicsWindow.Title` and `TextWindow.Title`, as suggested in https://github.com/sb/smallbasic-editor/issues/163#issuecomment-702754533. The result looks like this (title bars are only shown if title is specified):

![grafik](https://user-images.githubusercontent.com/26907770/96775803-59828b00-13e8-11eb-90de-21864228a0c8.png)

Fixes #163. 